### PR TITLE
fix: alert no. 3 - permissions in github workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,8 @@ concurrency:
 env:
     GO_VERSION: 1.22.3
 
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Kudora-Labs/kudora/security/code-scanning/3](https://github.com/Kudora-Labs/kudora/security/code-scanning/3)

To fix this problem, we should add a `permissions` block to the workflow, specifying that the GITHUB_TOKEN should only have read access to repository contents. The least privilege required for the job as currently written is `contents: read`. The best practice is to place the `permissions` block at the top level in the workflow (before `jobs:`), unless specific jobs require different permissions. You can add:

```yaml
permissions:
  contents: read
```

directly after the `env:` block and before `jobs:` in `.github/workflows/unit-test.yml`. No imports, methods, or additional definitions are needed, just the inclusion of this key in your YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
