### PR TITLE
fix: alert no. 2 - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testnet-hetzner.yml
+++ b/.github/workflows/testnet-hetzner.yml
@@ -1,5 +1,8 @@
 name: public cloud testnet
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/Kudora-Labs/kudora/security/code-scanning/2](https://github.com/Kudora-Labs/kudora/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the workflow. The appropriate place for this is at the root of the workflow YAML file (near the top, after the `name:` and `on:` keys), so that it applies to all jobs defined in the workflow unless overridden per-job. The minimal set of permissions for this workflow is likely `contents: read`, which allows the workflow to clone and access repository contents but not to make changes. The permissions block should be indented properly to match YAML standards.

The change requires editing `.github/workflows/testnet-hetzner.yml` by inserting the following lines:

```yaml
permissions:
  contents: read
```

This should be added after the `name:` line and before the `on:` block for maximal clarity and compliance with GitHub Actions YAML conventions. No further code changes or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
