### PR TITLE
fix: alert no. 1 - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,4 +1,6 @@
 name: Check Markdown links
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Kudora-Labs/kudora/security/code-scanning/1](https://github.com/Kudora-Labs/kudora/security/code-scanning/1)

To address the problem, we need to add an explicit `permissions` block to the workflow, limiting the permissions for the actions to the minimum required. For link-checking workflows, this would generally mean allowing only `contents: read` access to the repository, which is sufficient for reading Markdown files. This block should be added either at the root of the workflow (applies to all jobs) or under the specific job. Following best practice and as a starting point, we should add at the top-level of the workflow file, right after the `name:` block and before `jobs:`. No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
